### PR TITLE
Add instructions for including Forge jars for 1.15+

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -62,6 +62,12 @@ Building Baritone:
 $ gradlew build
 ```
 
+For minecraft 1.15.2+, you need to run the following instead if you want to include the Forge jars:
+
+```
+$ gradlew build -Pbaritone.forge_build
+```
+
 Running Baritone:
 
 ```


### PR DESCRIPTION
This will save someone some time figuring out why there are no forge jars

